### PR TITLE
Update Elasticsearch to 1.4

### DIFF
--- a/files/elasticsearch.repo
+++ b/files/elasticsearch.repo
@@ -1,6 +1,6 @@
 [elasticsearch-1.3]
-name=Elasticsearch repository for 1.3.x packages
-baseurl=http://packages.elasticsearch.org/elasticsearch/1.3/centos
+name=Elasticsearch repository for 1.4.x packages
+baseurl=http://packages.elasticsearch.org/elasticsearch/1.4/centos
 gpgcheck=1
 gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
 enabled=1

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,7 +6,7 @@
 
 - name: Add Elasticsearch repository.
   apt_repository:
-    repo: 'deb http://packages.elasticsearch.org/elasticsearch/1.1/debian stable main'
+    repo: 'deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main'
     state: present
 
 - name: Check if Elasticsearch is already installed.


### PR DESCRIPTION
I don't know why CentOS/Redhat is installing 1.3 while Debian installs 1.1.
But I know both should be updated to 1.4 if possible :)