### PR TITLE
Elasticsearch Version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ An Ansible Role that installs Elasticsearch on RedHat/CentOS or Debian/Ubuntu.
 
 None.
 
+## Variables
+
+Only for Debian/Ubuntu, the Elasticsearch Version to be installed can be customized via the
+"elasticsearch_version" variable. The default value is `1.4`.
+
+To override this default, define this variable with the desired value (e.g. `1.7`)
+in the Playbook or Inventory.
+
 ## Role Variables
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+elasticsearch_version: 1.4

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,7 +6,7 @@
 
 - name: Add Elasticsearch repository.
   apt_repository:
-    repo: 'deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main'
+    repo: 'deb http://packages.elasticsearch.org/elasticsearch/{{ elasticsearch_version }}/debian stable main'
     state: present
     update_cache: yes
 


### PR DESCRIPTION
This PR makes the Elasticsearch Version to be installed (only for
Debian distros) configurable via the variable "elasticsearch_version".

The default value is 1.4, for backwards compatibility.