### PR TITLE
Make network.host setting configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,22 @@ None.
 
 ## Role Variables
 
-None.
+Available variables are listed below, along with default values (see vars/main.yml):
+
+```
+es_network_host: localhost
+```
+
+Elasticsearch `network.host`
+[Setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html).
+
+To listen to multiple interfaces, e.g. on eth1 and localhost, use the
+array syntax and escape the quotes:
+
+```
+  roles:
+    - { role: geerlingguy.elasticsearch, es_network_host: '[\"_eth1:ipv4_\", \"localhost\"]' }
+```
 
 ## Dependencies
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     state=present
   with_items:
     - { regexp: '^script\.disable_dynamic', line: 'script.disable_dynamic: true' }
-    - { regexp: 'network\.host', line: 'network.host: localhost' }
+    - { regexp: 'network\.host', line: "network.host: {{ es_network_host }}" }
   notify: restart elasticsearch
 
 - name: Start Elasticsearch.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+es_network_host: localhost


### PR DESCRIPTION
This PR allows to configure the Elasticsearch `network.host` setting using a role variable.
