### PR TITLE
Take the Elasticsearch host to a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+es_network_host: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
   with_items:
     - { regexp: '^script\.inline', line: 'script.inline: on' }
     - { regexp: '^script\.indexed', line: 'script.indexed: on' }
-    - { regexp: 'network\.host', line: 'network.host: localhost' }
+    - { regexp: 'network\.host', line: 'network.host: {{es_network_host}}' }
   notify: restart elasticsearch
 
 - name: Start Elasticsearch.


### PR DESCRIPTION
I think it is a better way to manage the role, because a lots of people are using ES from remote. 