### PR TITLE
Elastic 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,29 @@ env:
   - distro: centos7
     init: /usr/lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    elastic_version: 2.x
   - distro: ubuntu1604
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    elastic_version: 2.x
+  - distro: ubuntu1604
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    elastic_version: 5.x
   - distro: ubuntu1404
     init: /sbin/init
     run_opts: ""
+    elastic_version: 2.x
   - distro: ubuntu1204
     init: /sbin/init
     run_opts: ""
+    elastic_version: 2.x
 
 before_install:
   # Pull container.
   - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
+  # elasticsearch 5.x requirement
+  - 'sudo sysctl -w vm.max_map_count=262144'
 
 script:
   - container_id=$(mktemp)
@@ -31,11 +41,11 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
 
   # Test role.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -e elasticsearch_repo_version=${elastic_version}'
 
   # Test role idempotence.
   - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -e elasticsearch_repo_version=${elastic_version} | tee -a ${idempotence}
   - >
     tail ${idempotence}
     | grep -q 'changed=0.*failed=0'

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Whether to allow inline scripting against ElasticSearch. You should read the fol
         - geerlingguy.java
         - geerlingguy.elasticsearch
 
+## FAQ
+
+* Elasticsearch 5.x require Java 8 which is only available on xenial with current role geerlingguy.java.
+
+* if run on openvz/lxc/docker, you have to set following settings high enough on host, else elasticsearch will not start
+```
+$ sudo sysctl -w vm.max_map_count=262144
+```
+(default: 65530)
+https://github.com/elastic/elasticsearch/issues/4978
+https://github.com/lxc/lxd/issues/2206
+
 ## License
 
 MIT / BSD

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+
+## 5.x requires java8!
+#elasticsearch_repo_version: 5.x
+elasticsearch_repo_version: 2.x
+
 elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
 elasticsearch_script_inline: true

--- a/files/elasticsearch.repo
+++ b/files/elasticsearch.repo
@@ -1,6 +1,0 @@
-[elasticsearch-2.x]
-name=Elasticsearch repository for 2.x packages
-baseurl=http://packages.elastic.co/elasticsearch/2.x/centos
-gpgcheck=1
-gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
-enabled=1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,8 +14,11 @@
     mode: 0750
   notify: restart elasticsearch
 
+- include: settings.yml
+
 - name: Start Elasticsearch.
   service: name=elasticsearch state=started enabled=yes
 
 - name: Make sure Elasticsearch is running before proceeding.
-  wait_for: port={{ elasticsearch_http_port }} delay=3 timeout=300
+  wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
+

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Reset MAX_MAP_COUNT as inside container - do the change on host!
+  lineinfile:
+    dest: /etc/default/elasticsearch
+    regexp: '^MAX_MAP_COUNT=.*'
+    line: 'MAX_MAP_COUNT='
+    backup: yes
+  when: ansible_os_family == 'Debian' and (ansible_virtualization_type == 'docker' or ansible_virtualization_type == 'lxc' or ansible_virtualization_type == 'openvz')
+

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Add apt-transport-https package
+  package: name=apt-transport-https state=present
+
 - name: Add Elasticsearch apt key.
   apt_key:
     url: https://packages.elastic.co/GPG-KEY-elasticsearch

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -32,3 +32,10 @@
 
 - name: Install Elasticsearch.
   apt: pkg=elasticsearch state=present
+  when: not (ansible_virtualization_type is defined and (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker"))
+
+- name: Install Elasticsearch. (containers)
+  apt: pkg=elasticsearch state=present
+  environment:
+    ES_SKIP_SET_KERNEL_PARAMETERS: 'true'
+  when: (ansible_virtualization_type is defined and (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker"))

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -39,3 +39,8 @@
   environment:
     ES_SKIP_SET_KERNEL_PARAMETERS: 'true'
   when: (ansible_virtualization_type is defined and (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker"))
+- name: add ES_SKIP_SET_KERNEL_PARAMETERS to /etc/environment
+  lineinfile:
+    dest: /etc/environment
+    line: "ES_SKIP_SET_KERNEL_PARAMETERS='true'"
+  when: (ansible_virtualization_type is defined and (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker"))

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,14 +1,31 @@
 ---
+
 - name: Add Elasticsearch apt key.
   apt_key:
     url: https://packages.elastic.co/GPG-KEY-elasticsearch
     state: present
 
-- name: Add Elasticsearch repository.
+- name: Add Elasticsearch repository. - 2.x
   apt_repository:
     repo: 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main'
     state: present
     update_cache: yes
+  when: elasticsearch_repo_version == '2.x'
+- block:
+    - name: check if any existing 1.x/2.x package
+      shell: "dpkg -s elasticsearch | egrep 'Version: [12]\\.'"
+      register: current
+      changed_when: false
+      ignore_errors: true
+    - name: fail if any existing 1.x/2.x package
+      fail: msg="This role CAN'T upgrade 1.x/2.x install! review documentation to do that."
+      when: current.stdout != ''
+    - name: Add Elasticsearch repository. - 5.x
+      apt_repository:
+        repo: 'deb https://artifacts.elastic.co/packages/5.x/apt stable main'
+        state: present
+        update_cache: yes
+  when: elasticsearch_repo_version == '5.x'
 
 - name: Install Elasticsearch.
   apt: pkg=elasticsearch state=present

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,12 +1,26 @@
 ---
+
+- block:
+    - name: check if any existing 1.x/2.x package
+#      shell: "rpm -q elasticsearch | egrep -- 'elasticsearch-[12]\.'"
+      command: "rpm -q elasticsearch"
+      register: current
+      changed_when: false
+      ignore_errors: true
+    - name: fail if any existing 1.x/2.x package
+      fail: msg="This role CAN'T upgrade 1.x/2.x install! review documentation to do that."
+      when: current.stdout.find('elasticsearch-1.') != -1 or current.stdout.find('elasticsearch-2.') != -1
+#      when: current.stdout != ''
+  when: elasticsearch_repo_version == '5.x'
+
 - name: Add Elasticsearch GPG key.
   rpm_key:
     key: https://packages.elastic.co/GPG-KEY-elasticsearch
     state: present
 
 - name: Add Elasticsearch repository.
-  copy:
-    src: elasticsearch.repo
+  template:
+    src: elasticsearch.repo.j2
     dest: /etc/yum.repos.d/elasticsearch.repo
     mode: 0644
 

--- a/templates/elasticsearch.repo.j2
+++ b/templates/elasticsearch.repo.j2
@@ -1,0 +1,17 @@
+{% if elasticsearch_repo_version == '2.x' %}
+[elasticsearch-2.x]
+name=Elasticsearch repository for 2.x packages
+baseurl=http://packages.elastic.co/elasticsearch/2.x/centos
+gpgcheck=1
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+{% else %}
+[elasticsearch-5.x]
+name=Elasticsearch repository for 5.x packages
+baseurl=https://artifacts.elastic.co/packages/5.x/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+{% endif %}

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -93,5 +93,9 @@ http.port: {{ elasticsearch_http_port }}
 # Require explicit names when deleting indices:
 #
 # action.destructive_requires_name: true
-script.inline: {{ elasticsearch_script_inline }}
-script.indexed: {{ elasticsearch_script_indexed }}
+script.inline: {{ elasticsearch_script_inline | lower }}
+{# 5.x: org.elasticsearch.bootstrap.StartupException: java.lang.IllegalArgumentException: unknown setting [script.indexed] did you mean any of [script.inline, script.ingest]? #}
+{% if elasticsearch_repo_version == '2.x' %}
+script.indexed: {{ elasticsearch_script_indexed | lower }}
+{% endif %}
+


### PR DESCRIPTION
add option for repo between elastic 2.x or 5.x - latest requires java8
travis test include only for xenial as only one with java8 in official distribution