### PR TITLE
Properly test the correct address

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,4 +18,4 @@
   service: name=elasticsearch state=started enabled=yes
 
 - name: Make sure Elasticsearch is running before proceeding.
-  wait_for: port={{ elasticsearch_http_port }} delay=3 timeout=300
+  wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300


### PR DESCRIPTION
Near the end of the playbook the task that checks if elasticsearch is
running always does so on localhost (default of the wait_for module).
When another bind address than localhost is used this does not work and
times out.