### PR TITLE
add option to install es plugins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
 elasticsearch_script_inline: true
 elasticsearch_script_indexed: true
+elasticsearch_plugins: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,8 @@
 
 - name: Make sure Elasticsearch is running before proceeding.
   wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
+
+- name: Install Elasticsearch plugins.
+  elasticsearch_plugin:
+    name: "{{ item }}"
+  with_items: "{{ elasticsearch_plugins }}"


### PR DESCRIPTION
Hi man!

I've added option to install elastic search plugins. This is supported natively by ansible so I see no reason why I should do it in different role :)

If you guide me a bit, I can add tests.