### PR TITLE
Changed 'include' to 'include_tasks'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Configure Elasticsearch.


### PR DESCRIPTION
as 'include' will be deprecated in ansible v2.8 changed 'include' to 'include_tasks'