### PR TITLE
Update main.yml - Added predifined dashboards

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,6 @@
   wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
 
 - name: import predefined dashboards
-  shell: /usr/share/metricbeat/scripts/import_dashboards -es http://{{elasticsearch_network_host}}:{{elasticsearch_http_port}}
+  shell: /usr/share/metricbeat/scripts/import_dashboards -es https://{{elasticsearch_network_host}}:{{elasticsearch_http_port}}
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,8 @@
 
 - name: Make sure Elasticsearch is running before proceeding.
   wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
+
+- name: import predefined dashboards
+  shell: /usr/share/metricbeat/scripts/import_dashboards -es http://{{elasticsearch_network_host}}:{{elasticsearch_http_port}}
+
+


### PR DESCRIPTION
After some research, I have concluded that there are a lot of people that do not have time or the knowledge to create visualisations for a dashboard. That's why I have added the option to choose some predifined dashboards (created by Elasticsearch) in the visualization plug-in (f.e. Kibana) that you would like to use.