### PR TITLE
Add support to configure JVM heap size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Network host to listen for incoming connections on. By default we only listen on
 
 The port to listen for HTTP connections on.
 
+    elasticsearch_heap_size_min: 2g
+
+The minimum jvm heap size.
+
+    elasticsearch_heap_size_max: 2g
+
+The maximum jvm heap size.
+
 ## Dependencies
 
   - geerlingguy.java

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,6 @@ elasticsearch_service_enabled: true
 
 elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
+
+elasticsearch_heap_size_min: 2g
+elasticsearch_heap_size_max: 2g

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,14 @@
     owner: root
     group: elasticsearch
     mode: 0660
+
+- name: Configure JVM.
+  template:
+    src: jvm.options.j2
+    dest: /etc/elasticsearch/jvm.options
+    owner: root
+    group: elasticsearch
+    mode: 0660
   notify: restart elasticsearch
 
 - name: Force a restart if configuration has changed.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,20 +12,14 @@
 
 - name: Configure Elasticsearch.
   template:
-    src: elasticsearch.yml.j2
-    dest: /etc/elasticsearch/elasticsearch.yml
+    src: "{{ item }}.j2"
+    dest: /etc/elasticsearch/{{ item }}
     owner: root
     group: elasticsearch
     mode: 0660
-
-- name: Configure JVM.
-  template:
-    src: jvm.options.j2
-    dest: /etc/elasticsearch/jvm.options
-    owner: root
-    group: elasticsearch
-    mode: 0660
-  notify: restart elasticsearch
+  with_items:
+    - elasticsearch.yml
+    - jvm.options
 
 - name: Force a restart if configuration has changed.
   meta: flush_handlers

--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -1,0 +1,111 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms{{ elasticsearch_heap_size_min }}
+-Xmx{{ elasticsearch_heap_size_max }}
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true


### PR DESCRIPTION
The initial and maximum size of the JVM heap can now be configured by using the following variables:

```
elasticsearch_heap_size_min: 512m
elasticsearch_heap_size_max: 512m
```