### PR TITLE
added correct apt repository for elasticsearch 2.x on debian.

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -22,4 +22,3 @@
     state: present
     update_cache: true
   when: elasticsearch_version == '2.x'
-  

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,3 +14,12 @@
     repo: 'deb https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/apt stable main'
     state: present
     update_cache: true
+  when: elasticsearch_version != '2.x'
+
+- name: Add Elasticsearch 2.x repository.
+  apt_repository:
+    repo: 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main'
+    state: present
+    update_cache: true
+  when: elasticsearch_version == '2.x'
+  


### PR DESCRIPTION
This change allow to correctly install elasticsearch 2.x.
This is based on https://github.com/geerlingguy/ansible-role-elasticsearch/issues/26#issuecomment-272689366