### PR TITLE
Skip checking if service is running when requested stated was stopped.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,3 +36,4 @@
     port: "{{ elasticsearch_http_port }}"
     delay: 3
     timeout: 300
+  when: elasticsearch_service_state == "started"


### PR DESCRIPTION
Currently if you set service to remain stopped installation will fail on task "Make sure Elasticsearch is running before proceeding."