### PR TITLE
38 add elasticsearch extra options variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ The minimum jvm heap size.
 
 The maximum jvm heap size.
 
+    elasticsearch_extra_options: ''
+
+A placeholder for configuration options not exposed by the role. The value you specicfy is written as-is to /etc/elasticsearch/elasticsearch.yml. Remember to preserve formatting with `|` if you need to write more than one line. For example:
+
+```yaml
+elasticsearch_extra_options: |
+  some.option: true
+  another.option: false
+```
+
 ## Dependencies
 
   - geerlingguy.java

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ The maximum jvm heap size.
 
     elasticsearch_extra_options: ''
 
-A placeholder for configuration options not exposed by the role. The value you specicfy is written as-is to /etc/elasticsearch/elasticsearch.yml. Remember to preserve formatting with `|` if you need to write more than one line. For example:
+A placeholder for arbitrary configuration options not exposed by the role. This will be appended as-is to the end of the elasticsearch.yml file, as long as your variable preserves formatting with a `|`. For example:
 
-```yaml
-elasticsearch_extra_options: |
-  some.option: true
-  another.option: false
-```
+  ```yaml
+  elasticsearch_extra_options: |     # Dont forget the pipe!
+    some.option: true
+    another.option: false
+  ```
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ elasticsearch_http_port: 9200
 
 elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g
+
+elasticsearch_extra_options: ''

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -87,3 +87,5 @@ http.port: {{ elasticsearch_http_port }}
 # Require explicit names when deleting indices:
 #
 #action.destructive_requires_name: true
+
+{{ elasticsearch_extra_options }}


### PR DESCRIPTION
As suggested in https://github.com/geerlingguy/ansible-role-elasticsearch/issues/38 , this adds an open-ended way to configure extra elasticache options when needed, without adding any unnecessary complexity.