### PR TITLE
Allow package name and version to be specified

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 elasticsearch_version: '7.x'
+elasticsearch_package: elasticsearch
 elasticsearch_package_state: present
 
 elasticsearch_service_state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Install Elasticsearch.
   package:
-    name: elasticsearch
+    name: "{{ elasticsearch_package }}"
     state: "{{ elasticsearch_package_state }}"
 
 - name: Configure Elasticsearch.


### PR DESCRIPTION
This PR will allow us to specify exactly which version of Elasticsearch to install. Defaults to "elasticsearch", so this is not a breaking change.