### PR TITLE
Disable elasticsearch repo by default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
   package:
     name: elasticsearch
     state: "{{ elasticsearch_package_state }}"
+    enablerepo: "elasticsearch-{{ elasticsearch_version }}"
 
 - name: Configure Elasticsearch.
   template:

--- a/templates/elasticsearch.repo.j2
+++ b/templates/elasticsearch.repo.j2
@@ -3,6 +3,6 @@ name=Elasticsearch repository for {{ elasticsearch_version }} packages
 baseurl=https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
-enabled=1
+enabled=0
 autorefresh=1
 type=rpm-md


### PR DESCRIPTION
As per official recommendations, it's a good idea to have the elasticsearch repository disabled by default to avoid accidentally updating it:

https://www.elastic.co/guide/en/elasticsearch/reference/current/rpm.html

> The configured repository is disabled by default. This eliminates the possibility of accidentally upgrading elasticsearch when upgrading the rest of the system.

I was bitten by this yesterday as a system update upgraded elasticsearch from 7.5.1 to 7.5.2 which broke everything, as the installed plugins were for 7.5.1.