### PR TITLE
Make the min and max heap size share same default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The port to listen for HTTP connections on.
 
     elasticsearch_heap_size_min: 1g
 
-The minimum jvm heap size.
+The minimum JVM heap size.
 
-    elasticsearch_heap_size_max: 2g
+    elasticsearch_heap_size_max: 1g
 
-The maximum jvm heap size.
+The maximum JVM heap size. You should always set the min and max JVM heap size to the same value.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,4 @@ elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
 
 elasticsearch_heap_size_min: 1g
-elasticsearch_heap_size_max: 2g
+elasticsearch_heap_size_max: 1g


### PR DESCRIPTION
I’ve noticed that the default configuration will cause nodes to fail to start if they bind to a non-loopback address, which is common in production clusters:

```
[INFO ][o.e.b.BootstrapChecks    ] [app-node-1] bound or publishing to a non-loopback address, enforcing bootstrap checks
[ERROR][o.e.b.Bootstrap          ] [app-node-1] node validation exception
[1] bootstrap checks failed
[1]: initial heap size [1073741824] not equal to maximum heap size [2147483648]; this can cause resize pauses and prevents mlockall from locking the entire heap
```

The change to the min heap size was introduced in https://github.com/geerlingguy/ansible-role-elasticsearch/commit/87cdb6ace1dc04dd3670eb3484effb4de29501a4 – since `jvm.options` recommends having min and max set to the same value, I've updated the max value to reflect this change.