### PR TITLE
Replace min/max heap with Single `elasticsearch_heap_size` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,9 @@ Network host to listen for incoming connections on. By default we only listen on
 
 The port to listen for HTTP connections on.
 
-    elasticsearch_heap_size_min: 1g
+    elasticsearch_heap_size: 2g
 
-The minimum jvm heap size.
-
-    elasticsearch_heap_size_max: 2g
-
-The maximum jvm heap size.
+The jvm heap size.
 
     elasticsearch_extra_options: ''
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,6 @@ elasticsearch_service_enabled: true
 elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
 
-elasticsearch_heap_size_min: 1g
-elasticsearch_heap_size_max: 2g
+elasticsearch_heap_size: 2g
 
 elasticsearch_extra_options: ''

--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -19,8 +19,8 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
--Xms{{ elasticsearch_heap_size_min }}
--Xmx{{ elasticsearch_heap_size_max }}
+-Xms{{ elasticsearch_heap_size }}
+-Xmx{{ elasticsearch_heap_size }}
 
 ################################################################
 ## Expert settings


### PR DESCRIPTION
Replace minimum and maximum heap size declarations with single declaration of `elasticsearch_heap_size`.

This replacement is to better line up with both the given comments in the jvm.options.j2 template stating that maximum heap size must equal minimum heap size, as well as to match the official elastic repository. Variability between the two can result in elasticsearch either not running or instability.

Closes #62 