### PR TITLE
Define Parameter for Installing a Specific Version of Elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The major version to use when installing Elasticsearch.
 
+    elasticsearch_package_version: ''
+
+The package version to use when installing Elasticsearch.
+
     elasticsearch_package_state: present
 
 The `elasticsearch` package state; set to `latest` to upgrade or change versions.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 elasticsearch_version: '7.x'
+elasticsearch_package_version: ''
 elasticsearch_package_state: present
 
 elasticsearch_service_state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Install specific version of Elasticsearch.
   package:
-    name: "elasticsearch-{{ elasticsearch_package_version }}"
+    name: "elasticsearch{{ (ansible_os_family == 'Debian') | ternary('=','-') }}{{ elasticsearch_package_version }}"
     state: "{{ elasticsearch_package_state }}"
   when: elasticsearch_package_version != ''
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,13 @@
   package:
     name: elasticsearch
     state: "{{ elasticsearch_package_state }}"
+  when: elasticsearch_package_version == ''
+
+- name: Install specific version of Elasticsearch.
+  package:
+    name: "elasticsearch-{{ elasticsearch_package_version }}"
+    state: "{{ elasticsearch_package_state }}"
+  when: elasticsearch_package_version != ''
 
 - name: Configure Elasticsearch.
   template:


### PR DESCRIPTION
Defines a new parameter `elasticsearch_package_version` as to allow for specific version installs.