### PR TITLE
feat: Allow overloading of path.data property

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The minimum jvm heap size.
 
     elasticsearch_heap_size_max: 2g
 
+The data path
+    elasticsearch_path_data: '/var/lib/elasticsearch'
+
 The maximum jvm heap size.
 
     elasticsearch_extra_options: ''

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The minimum jvm heap size.
 
     elasticsearch_heap_size_max: 2g
 
-The data path
+The data path.
+
     elasticsearch_path_data: '/var/lib/elasticsearch'
 
 The maximum jvm heap size.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,6 @@ elasticsearch_http_port: 9200
 elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g
 
+elasticsearch_path_data: '/var/lib/elasticsearch'
+
 elasticsearch_extra_options: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,12 @@
     - jvm.options
   notify: restart elasticsearch
 
+- name: Ensure Elasticseach data path is reachable
+  file:
+    path: "{{ elasticsearch_path_data }}"
+    state: directory
+    owner: elasticsearch
+    group: elasticsearch
 - name: Force a restart if configuration has changed.
   meta: flush_handlers
 

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -31,7 +31,7 @@
 #
 # Path to directory where to store the data (separate multiple locations by comma):
 #
-path.data: /var/lib/elasticsearch
+path.data: {{ elasticsearch_path_data }}
 #
 # Path to log files:
 #


### PR DESCRIPTION
Your role is quite useful but doesn't allow one to overload the `path.data` property of the configuration file. I needed and though you might be interested in it.