### PR TITLE
dependency on geerlingguy.java role redundant and should not be used

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,5 @@
 ---
-dependencies:
-  - geerlingguy.java
+dependencies: []
 
 galaxy_info:
   role_name: elasticsearch


### PR DESCRIPTION
Like role geerlingguy.kibana doesn't have elasticsearch dependency, and geerlingguy.logstash doesn't have geerlingguy.elasticsearch dependency, I believe this requirement also should be removed.
It's more complicated to use this role in non-galaxy environment otherwise, tnx