### PR TITLE
Configure path for logs and data

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,7 @@ elasticsearch_http_port: 9200
 elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g
 
+elasticsearch_path_data: /var/lib/elasticsearch
+elasticsearch_path_logs: /var/log/elasticsearch
+
 elasticsearch_extra_options: ''

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -31,11 +31,11 @@
 #
 # Path to directory where to store the data (separate multiple locations by comma):
 #
-path.data: /var/lib/elasticsearch
+path.data: {{ elasticsearch_path_data }}
 #
 # Path to log files:
 #
-path.logs: /var/log/elasticsearch
+path.logs: {{ elasticsearch_path_logs }}
 #
 # ----------------------------------- Memory -----------------------------------
 #


### PR DESCRIPTION
As a user of Elasticsearch and your Elasticsearch Ansible role I want to configure my Elasticsearch logs and data on a separate disk.

The current configuration hard codes these to a default location.
Overriding these with extra parameters will give configuration for the same configuration parameter twice with different values.

This merge-request defines two new variables with your defaults. These are now used in the template.