### PR TITLE
Do not start Elasticsearch from role when it is configured to not be started

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
     name: elasticsearch
     state: "{{ elasticsearch_service_state }}"
     enabled: "{{ elasticsearch_service_enabled }}"
+  when: elasticsearch_service_state == true
 
 - name: Make sure Elasticsearch is running before proceeding.
   wait_for:
@@ -37,3 +38,4 @@
     port: "{{ elasticsearch_http_port }}"
     delay: 3
     timeout: 300
+  when: elasticsearch_service_state == true


### PR DESCRIPTION
The current role always starts Elasticsearch regardless of the settings.
This allows for configuring certain aspects currently not in the role.

This assumes the path configuration merge request was already merged.

## Motiviation

The role does not configure memlock or max op files. If you turn memlock on in `elasticsearch.yml` it on you should also override systemd configuration. This is also the place for setting the max open files on Debian systems.

I need to be able to create directories for logs and data before the service is started.

For cluster usage I need to copy certificate files.

I think the memlock option might be a candidate to be included in the role after careful consideration.
Please for now allow us to not start Elasticsearch with your role and handle that ourselves.

### systemd override.conf

```
[Service]
LimitMEMLOCK=infinity
LimitNOFILE=65535
```

## Example playbook using your altered role

This allows me to configure a working Elasticsearch cluster with 3 nodes.

```YAML
---
- name: Configure Elasticsearch on Elasticsearch cluster machines.
  hosts: elasticsearch_cluster
  become: true
  gather_facts: true
  vars_files:
  - 'environments/{{ environment_name }}/vars/environment.yml'
  - 'environments/{{ environment_name }}/vars/secrets.yml'
  - 'vars/elasticsearch_cluster.yml'
  vars:
    # Do not enable or start Elasticsearch with the role because we need to
    # configure the cluster first. This cannot be done in a pre_task because
    # then needed directories are not yet created.
    # Elasticsearch will be started as a last step in tasks
    elasticsearch_service_state: stopped
    elasticsearch_service_enabled: false
    elasticsearch_heap_size_min: '{{ elasticsearch_memory }}'
    elasticsearch_heap_size_max: '{{ elasticsearch_memory }}'
    elasticsearch_network_host: '{{ ansible_default_ipv4.address }}'
    elasticsearch_http_port: 9200
    elasticsearch_path_data: /opt/data/es_indices
    elasticsearch_path_logs: /opt/data/logs
    elasticsearch_extra_options: |
      cluster.name: my_awesome_cluster
      node.name: {{ elasticsearch_node_name }}
      node.attr.rack: lams_rack
      bootstrap.memory_lock: true
      discovery.seed_hosts: {{ elasticsearch_hosts }}
      cluster.initial_master_nodes: {{ elasticsearch_hosts }}
      gateway.recover_after_nodes: 2
      node.ml: false
      xpack.ml.enabled: false
      xpack.security.transport.ssl.enabled: true
      xpack.security.transport.ssl.verification_mode: certificate
      xpack.security.transport.ssl.keystore.path: /etc/elasticsearch/certs/elastic-certificates.p12
      xpack.security.transport.ssl.truststore.path: /etc/elasticsearch/certs/elastic-certificates.p12
  roles:
    - geerlingguy.java
    - geerlingguy.elasticsearch
  tasks:
    - name: Create directory to store Elasticsearch systemd override.
      file:
        path: /etc/systemd/system/elasticsearch.service.d
        state: directory
        owner: root
        group: root
        mode: 0755
    - name: Copy Elasticsearch systemd configuration override.
      copy:
        src: files/elasticsearch_cluster/etc/systemd/system/elasticsearch.service.d/override.conf
        dest: /etc/systemd/system/elasticsearch.service.d/override.conf
        owner: root
        group: root
        mode: 0644
    - name: Create directory to store Elasticsearch certs.
      file:
        path: /etc/elasticsearch/certs
        state: directory
        owner: elasticsearch
        group: elasticsearch
        mode: 0700
    - name: Create directory to store Elasticsearch logs.
      file:
        path: /etc/elasticsearch/certs
        state: directory
        owner: elasticsearch
        group: elasticsearch
        mode: 0700
    - name: Copy Elasticsearch certificates before Elasticsearch is started.
      copy:
        src:  files/elasticsearch_cluster/elastic-certificates.p12
        dest: /etc/elasticsearch/certs/elastic-certificates.p12
        owner: elasticsearch
        group: elasticsearch
        mode: 0600
    - name: Create directory to store Elasticsearch logs.
      file:
        path: /opt/data/logs
        state: directory
        owner: elasticsearch
        group: elasticsearch
        mode: 0755
    - name: Create directory to store Elasticsearch data.
      file:
        path: /opt/data/es_indices
        state: directory
        recurse: true
        owner: elasticsearch
        group: elasticsearch
        mode: 0755
    - name: Enable and start Elasticsearch.
      # Use systemd instead of service because we touched systemd configuration
      # that needs to be reloaded
      systemd:
        name: elasticsearch
        state: restarted
        enabled: true
        daemon_reload: true
```