### PR TITLE
feat: set heap min and max to the same value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,6 @@ elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
 
 elasticsearch_heap_size_min: 1g
-elasticsearch_heap_size_max: 2g
+elasticsearch_heap_size_max: 1g
 
 elasticsearch_extra_options: ''


### PR DESCRIPTION
By [https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html):

> Elasticsearch will assign the entire heap specified in jvm.options via the Xms (minimum heap size) and Xmx (maximum heap size) settings. These two settings must be equal to each other.

This sets both min and max to be equal to 1g, which is the default.