### PR TITLE
install specific elasticsearch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The major version to use when installing Elasticsearch.
 
+    elasticsearch_package_version: '7.4.2'
+
+The exact version to use when installing Elasticsearch.
+
     elasticsearch_package_state: present
 
 The `elasticsearch` package state; set to `latest` to upgrade or change versions.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 elasticsearch_version: '7.x'
 elasticsearch_package_state: present
+elasticsearch_package_version: 7.10.2
 
 elasticsearch_service_state: started
 elasticsearch_service_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Install Elasticsearch.
   package:
-    name: elasticsearch
+    name: "elasticsearch-{{ elasticsearch_package_version }}"
     state: "{{ elasticsearch_package_state }}"
 
 - name: Configure Elasticsearch 6 or below.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
this pr solve issue #81  .

#### What this PR does / why we need it:
This PR creates an additional variable called `elasticsearch_package_version` which defaults to `7.10.2` to be able to install specific version of elasticsearch instead of latest version in the elasticsearch 7.x repositories.

#### Special notes for your reviewer:
I have also modified the README.md[README.md]