### PR TITLE
Remove elastic search heap options dependency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,6 @@
     mode: 0660
   with_items:
     - /etc/elasticsearch/elasticsearch.yml
-    - /etc/elasticsearch/jvm.options.d/heap.options
   notify: restart elasticsearch
   when: elasticsearch_version[0] | int >= 7
 


### PR DESCRIPTION
Remove line /etc/elasticsearch/jvm.options.d/heap.options. This line causes the whole build to fail since it doesn't exist.