### PR TITLE
Fix jvm.options for ES6 JDK11 on Ubuntu 20.04

### DIFF
--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -102,10 +102,10 @@
 
 # specify an alternative path for heap dumps; ensure the directory exists and
 # has sufficient space
--XX:HeapDumpPath=data
+-XX:HeapDumpPath=/var/lib/elasticsearch
 
 # specify an alternative path for JVM fatal error logs
--XX:ErrorFile=logs/hs_err_pid%p.log
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
 
 ## JDK 8 GC logging
 
@@ -113,13 +113,13 @@
 8:-XX:+PrintGCDateStamps
 8:-XX:+PrintTenuringDistribution
 8:-XX:+PrintGCApplicationStoppedTime
-8:-Xloggc:logs/gc.log
+8:-Xloggc:/var/log/elasticsearch/gc.log
 8:-XX:+UseGCLogFileRotation
 8:-XX:NumberOfGCLogFiles=32
 8:-XX:GCLogFileSize=64m
 
 # JDK 9+ GC logging
-9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
 # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
 # time/date parsing will break in an incompatible way for some date patterns and locals
 9-:-Djava.locale.providers=COMPAT


### PR DESCRIPTION
Fixes #85 