### PR TITLE
Add ability to override template

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ elasticsearch_extra_options: |  # Dont forget the pipe!
   another.option: false
 ```
 
+For those needing more control, you can use template name varibles to override the config file templates. The easiest way to do this is create a template relavent to your playbook in ./templates/ and override the name variable.
+
+```yaml
+elasticsearch_elasticsearch_yml_template: elasticsearch.yml.j2
+elasticsearch_heap_options_template: heap.options.j2
+elasticsearch_jvm_options_template: jvm.options.j2
+```
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,7 @@ elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g
 
 elasticsearch_extra_options: ''
+
+elasticsearch_elasticsearch_yml_template: elasticsearch.yml.j2
+elasticsearch_heap_options_template: heap.options.j2
+elasticsearch_jvm_options_template: jvm.options.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     owner: root
     group: elasticsearch
     mode: 0660
-  with_items:
+  loop:
     - dest: /etc/elasticsearch/elasticsearch.yml
       template: "{{ elasticsearch_elasticsearch_yml_template }}"
 
@@ -36,7 +36,7 @@
     owner: root
     group: elasticsearch
     mode: 0660
-  with_items:
+  loop:
     - dest: /etc/elasticsearch/elasticsearch.yml
       template: "{{ elasticsearch_elasticsearch_yml_template }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,30 +12,37 @@
     state: "{{ elasticsearch_package_state }}"
 
 - name: Configure Elasticsearch 6 or below.
+  when: elasticsearch_version[0] | int < 7
   template:
-    src: "{{ item | basename }}.j2"
-    dest: "{{ item }}"
+    src: "{{ item.template }}"
+    dest: "{{ item.dest }}"
     owner: root
     group: elasticsearch
     mode: 0660
   with_items:
-    - /etc/elasticsearch/elasticsearch.yml
-    - /etc/elasticsearch/jvm.options
+    - dest: /etc/elasticsearch/elasticsearch.yml
+      template: "{{ elasticsearch_elasticsearch_yml_template }}"
+
+    - dest: /etc/elasticsearch/jvm.options
+      template: "{{ elasticsearch_jvm_options_template }}"
   notify: restart elasticsearch
-  when: elasticsearch_version[0] | int < 7
+  
 
 - name: Configure Elasticsearch 7+.
+  when: elasticsearch_version[0] | int >= 7
   template:
-    src: "{{ item | basename }}.j2"
-    dest: "{{ item }}"
+    src: "{{ item.template }}"
+    dest: "{{ item.dest }}"
     owner: root
     group: elasticsearch
     mode: 0660
   with_items:
-    - /etc/elasticsearch/elasticsearch.yml
-    - /etc/elasticsearch/jvm.options.d/heap.options
+    - dest: /etc/elasticsearch/elasticsearch.yml
+      template: "{{ elasticsearch_elasticsearch_yml_template }}"
+
+    - dest: /etc/elasticsearch/jvm.options.d/heap.options
+      template: "{{ elasticsearch_heap_options_template }}"
   notify: restart elasticsearch
-  when: elasticsearch_version[0] | int >= 7
 
 - name: Force a restart if configuration has changed.
   meta: flush_handlers


### PR DESCRIPTION
Hello,

First thanks for making this and so many other great roles I use all the time.

Add the ability to override the templates with your own template using variables.

I needed a bit more flexibility. I created default vars with the name of your templates and used those vars to call the templates in the tasks. Now you can set those vars to your own templates names and ansible will find them based on the lookup hierarchy. role → playbook → etc.
