### PR TITLE
Add fix for log4shell vulnerability

### DIFF
--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -92,6 +92,9 @@
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
 
+# Fix for log4shell exploit
+-Dlog4j2.formatMsgNoLookups=true
+
 -Djava.io.tmpdir=${ES_TMPDIR}
 
 ## heap dumps


### PR DESCRIPTION
Add formatMsgNoLookups boolean to jvm.options configuration to prevent log4j attack vectors.  As per [this article](https://xeraa.net/blog/2021_mitigate-log4j2-log4shell-elasticsearch/#linux-service-ubuntu).