### PR TITLE
Do not fail playbook when state is stopped

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart elasticsearch
   service: name=elasticsearch state=restarted
+  when: elasticsearch_service_state != 'stopped'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,3 +52,4 @@
     port: "{{ elasticsearch_http_port }}"
     delay: 3
     timeout: 300
+  when: elasticsearch_service_state != 'stopped'


### PR DESCRIPTION
When building ami using packer, i don't need elasticsearch to be started. But even if i set elasticsearch_service_state equal to stopped, handler is still trying to restart elasticsearch and wait_for waiting for elasticsearch to be available. By adding this condition ansible run completed successfully without starting elasticsearch

Before

```shell
    elasticsearch.amazon-ebs.elasticsearch: TASK [geerlingguy.elasticsearch : Force a restart if configuration has changed.] ***
    elasticsearch.amazon-ebs.elasticsearch:
    elasticsearch.amazon-ebs.elasticsearch: RUNNING HANDLER [geerlingguy.elasticsearch : restart elasticsearch] ************
    elasticsearch.amazon-ebs.elasticsearch: fatal: [default]: FAILED! => {"changed": false, "msg": "Unable to start service elasticsearch: Job for elasticsearch.service failed because the control process exited with error code. See \"systemctl status elasticsearch.service\" and \"journalctl -xe\" for details.\n"}
    elasticsearch.amazon-ebs.elasticsearch:
    elasticsearch.amazon-ebs.elasticsearch: PLAY RECAP *********************************************************************
    elasticsearch.amazon-ebs.elasticsearch: default                    : ok=10   changed=5    unreachable=0    failed=1    skipped=8    rescued=0    ignored=0
```

After

```shell
  elasticsearch.amazon-ebs.elasticsearch:
    elasticsearch.amazon-ebs.elasticsearch: TASK [../../ansible-role-elasticsearch : Force a restart if configuration has changed.] ***
    elasticsearch.amazon-ebs.elasticsearch:
    elasticsearch.amazon-ebs.elasticsearch: RUNNING HANDLER [../../ansible-role-elasticsearch : restart elasticsearch] *****
    elasticsearch.amazon-ebs.elasticsearch: skipping: [default]
    elasticsearch.amazon-ebs.elasticsearch:
    elasticsearch.amazon-ebs.elasticsearch: TASK [../../ansible-role-elasticsearch : Start Elasticsearch.] *****************
    elasticsearch.amazon-ebs.elasticsearch: changed: [default]
    elasticsearch.amazon-ebs.elasticsearch:
    elasticsearch.amazon-ebs.elasticsearch: TASK [../../ansible-role-elasticsearch : Make sure Elasticsearch is running before proceeding.] ***
    elasticsearch.amazon-ebs.elasticsearch: skipping: [default]
    elasticsearch.amazon-ebs.elasticsearch:
    elasticsearch.amazon-ebs.elasticsearch: PLAY RECAP *********************************************************************
    elasticsearch.amazon-ebs.elasticsearch: default                    : ok=11   changed=6    unreachable=0    failed=0    skipped=10   rescued=0    ignored=0
```