### PR TITLE
adding apt priority configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ elasticsearch_service_enabled: true
 
 elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
+elasticsearch_log: /var/log/elasticsearch
+elasticsearch_data: /var/lib/elasticsearch
 
 elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g
 
 elasticsearch_extra_options: ''
+elasticsearch_apt_priority: 100

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,3 +16,11 @@
     repo: 'deb https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/apt stable main'
     state: present
     update_cache: true
+
+- name: Lower apt priority from Elasticsearch repository (do not trust that repo for anything different)
+  template:
+    src: elasticsearch_policy.j2
+    dest: /etc/apt/preferences.d/elasticsearch_policy_100
+    owner: root
+    group: root
+    mode: 0644

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -31,11 +31,11 @@
 #
 # Path to directory where to store the data (separate multiple locations by comma):
 #
-path.data: /var/lib/elasticsearch
+path.data: {{ elasticsearch_data }}
 #
 # Path to log files:
 #
-path.logs: /var/log/elasticsearch
+path.logs: {{ elasticsearch_log }}
 #
 # ----------------------------------- Memory -----------------------------------
 #

--- a/templates/elasticsearch_policy.j2
+++ b/templates/elasticsearch_policy.j2
@@ -1,0 +1,3 @@
+Package:  *
+Pin:  origin artifacts.elastic.co
+Pin-Priority: {{ elasticsearch_apt_priority }}


### PR DESCRIPTION
When using apt to install package, I prefer, for security reason, lower apt policy of a new PPA to 100 to prevent new repository to mess up with already install package from standard repository.  I added a variable to tune the parameter in case we want some other value.

Here is the value meaning (standard is 500):

500 to 899. Install a version unless there is a version available belonging to the target release or the installed version is more recent.

100 to 499. Install a version unless there is a version available belonging to some other distribution or the installed version is more recent. 