### PR TITLE
setting update_cache to true

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,7 +5,8 @@
       - apt-transport-https
       - gnupg2
     state: present
-
+    update_cache: true
+    
 - name: Add Elasticsearch apt key.
   apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch


### PR DESCRIPTION
In some cases, if cache isn't updated, gnupg2 package does not appear on apt package list and consequently role fail. It happened when I was testing a other role depending on this one.

I suggest to add update apt cache to resolve this issue