### PR TITLE
Removed outdated reference to default variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requires at least Java 8. You can use the [`geerlingguy.java`](https://github.co
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml` for default role variables, `vars/RedHat.yml` and  `vars/Debian.yml` for distribution specific variables):
+Available variables are listed below, along with default values (see `defaults/main.yml` for default role variables).
 
     elasticsearch_version: '7.x'
 


### PR DESCRIPTION
The `vars/` folder does not exist anymore. Updated `README.md`.