### PR TITLE
Better handling of the service in stopped state

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart elasticsearch
   service: name=elasticsearch state=restarted
+  when: elasticsearch_service_state == 'started'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,3 +52,4 @@
     port: "{{ elasticsearch_http_port }}"
     delay: 3
     timeout: 300
+  when: elasticsearch_service_state == 'started'


### PR DESCRIPTION
- Prevented waiting for Elasticsearch when `elasticsearch_service_state` is set to `stopped`.
- Avoided triggering 'restart elasticsearch' handler under the same condition.

**Reasoning:**
Encountered a need to configure security features mandatory for Elasticsearch 8.x. Initial attempts to configure pre-installation were unsuccessful, as these settings require Elasticsearch to be installed first. Thus, opted for post-installation configuration. This necessitated the ability to install and configure Elasticsearch without starting the service.

**Note:**
Security settings required by default in Elasticsearch 8.x ideally should be incorporated into the role itself. Plan to explore adding this support to the existing role when possible.