### PR TITLE
Wait for Elasticsearch reachability only if it is started

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
 
 - name: Force a restart if configuration has changed.
   meta: flush_handlers
+  when: elasticsearch_service_state == "started"
 
 - name: Start Elasticsearch.
   service:
@@ -52,3 +53,4 @@
     port: "{{ elasticsearch_http_port }}"
     delay: 3
     timeout: 300
+  when: elasticsearch_service_state == "started"


### PR DESCRIPTION
Currently the role always waits for Elasticsearch to become reachable on the http port, but if `elasticsearch_service_state` is set to `stopped` because eg. additional config is needed (cluster certs etc) the role hangs on waiting for reachability before failing with a timeout.