### PR TITLE
fix apt-key deprecation

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -7,12 +7,14 @@
     state: present
 
 - name: Add Elasticsearch apt key.
-  apt_key:
+  ansible.builtin.get_url:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    state: present
+    dest: /usr/share/keyrings/elasticsearch-keyring.asc
+    mode: '0644'
+    force: true
 
 - name: Add Elasticsearch repository.
   apt_repository:
-    repo: 'deb https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/apt stable main'
+    repo: 'deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.asc] https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/apt stable main'
     state: present
     update_cache: true


### PR DESCRIPTION
[Reopen PR]

For security reasons, apt-key is deprecated, key should not be stored in /etc/apt/trusted.gpg anymore but into /usr/share/keyrings or into /etc/apt/keyrings for manually added stuff. It allows to add keys individually and specify which on should be use per repo.

