### PR TITLE
Consistently access facts via the ansible_facts.* namespace

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,7 +6,7 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=true cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
       changed_when: false
 
   roles:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,8 +17,5 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      inject_facts_as_vars: false
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,5 +17,8 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      inject_facts_as_vars: false
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
 - include_tasks: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - include_tasks: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - name: Install Elasticsearch.
   package:


### PR DESCRIPTION
Currently, the role failed to run with `INJECT_FACTS_AS_VARS` set to `False` as the required `ansible_*` variables are not defined.

The configuration variable `INJECT_FACTS_AS_VARS` and the Ansible fact namespace `ansible_facts.*` have been added in Ansible 2.5. In the [porting guide of that version](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#ansible-fact-namespacing), it stated that:

> A new configuration variable, `inject_facts_as_vars`, has been added to ansible.cfg. Its default setting, 'True', keeps the 2.4 behavior of facts variables being set in the old `ansible_*` locations (while also writing them to the new namespace). This variable is expected to be set to 'False' in a future release. When `inject_facts_as_vars` is set to False, you must refer to ansible_facts through the new `ansible_facts.*` namespace.