### PR TITLE
Fix typo in README regarding Java installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Ansible Role that installs Elasticsearch on RedHat/CentOS or Debian/Ubuntu.
 
 ## Requirements
 
-Requires at least Java 8. You can use the [`geerlingguy.java`](https://github.com/geerlingguy/ansible-role-java) to easilly install Java.
+Requires at least Java 8. You can use the [`geerlingguy.java`](https://github.com/geerlingguy/ansible-role-java) role to easily install Java.
 
 ## Role Variables
 


### PR DESCRIPTION
Replace "You can use the [geerlingguy.java](https://github.com/geerlingguy/ansible-role-java) to easilly install Java." with "You can use the [geerlingguy.java](https://github.com/geerlingguy/ansible-role-java) role to easily install Java." in readme line 9